### PR TITLE
Implemented missing data type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ The supported column types with their return Go types are:
 
 | Column Type | Column Type Name | Golang type |
 |------------|-----------------|-------------|
-| B | Double | float64 |
 | C | Character | string |
+| Y | Currency | float64 |
+| B | Double | float64 |
 | D | Date | time.Time |
+| T | DateTime | time.Time | 	
 | F | Float | float64 |
 | I | Integer | int32 |
 | L | Logical | bool |
@@ -51,10 +53,15 @@ The supported column types with their return Go types are:
 | M | Memo (Binary) | []byte |
 | N | Numeric (0 decimals) | int64 |
 | N | Numeric (with decimals) | float64 |
-| T | DateTime | time.Time |
-| Y | Currency | float64 |
+| W* | Blob | []byte |
+| G* | General | []byte |
+| P* | Picture | []byte |
+| P* | Picture | []byte |
+| V* | Varchar | []byte |
 
 > If you need more information about dbase data types take a look here: [Microsoft Visual Studio Foxpro](https://learn.microsoft.com/en-us/previous-versions/visualstudio/foxpro/74zkxe2k(v=vs.80))
+
+> **These types are not interpreted by this package, the raw data is returned. This means the user must interpret the values themselves.*
 
 # Installation
 ``` 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ There are several similar packages but they are not suited for our use case, thi
 | Read | ✅ | ✅ | ✅ |
 | Write | ✅  | ✅ | ❌ |
 | FPT (memo) file support | ✅ | ❌ | ✅ |
-| Data type support | ✅ | ❌ | ✅ |
 | Struct, json, map conversion | ✅ | ❌ | ✅ |
 | IO efficiency ² | ✅ | ❌ | ✅ |
+| Full data type support | ✅ | ❌ | ❌ |
 | Non full blocking IO³ | ✅ | ❌ | ❌ |
 | Search by value | ✅ | ❌ | ❌ |
 

--- a/dbase/interpreter.go
+++ b/dbase/interpreter.go
@@ -64,9 +64,6 @@ func (dbf *DBF) dataToValue(raw []byte, column *Column) (interface{}, error) {
 	case "L":
 		// L values are stored as strings T or F, we only check for T, the rest is false...
 		return dbf.parseLValue(raw)
-	case "V":
-		// V values just return the raw value
-		return dbf.parseVValue(raw, column)
 	case "Y":
 		// Y values are currency values stored as ints with 4 decimal places
 		return dbf.parseYValue(raw)
@@ -76,6 +73,21 @@ func (dbf *DBF) dataToValue(raw []byte, column *Column) (interface{}, error) {
 	case "F":
 		// F values are stored as string values
 		return dbf.parseFValue(raw, column)
+	case "Q":
+		// Q values just return the raw value
+		fallthrough
+	case "V":
+		// V values just return the raw value
+		fallthrough
+	case "W":
+		// W values just return the raw value
+		fallthrough
+	case "P":
+		// P values just return the raw value
+		fallthrough
+	case "G":
+		// G values just return the raw value
+		return dbf.parseRawValue(raw, column)
 	default:
 		return nil, newError("dbase-interpreter-datatovalue-2", fmt.Errorf("unsupported column data type: %s", column.Type()))
 	}
@@ -114,12 +126,24 @@ func (dbf *DBF) valueToByteRepresentation(field *Field, skipSpacing bool) ([]byt
 	case "L":
 		// L (bool) values are stored as strings T or F, we only check for T, the rest is false...
 		return dbf.getLRepresentation(field)
-	case "V":
-		// V values just return the raw value
-		return dbf.getVRepresentation(field)
 	case "N":
 		// N values are stored as string values, if no decimals return as int64, if decimals treat as float64
 		return dbf.getNRepresentation(field, skipSpacing)
+	case "Q":
+		// Q values just return the raw value
+		fallthrough
+	case "V":
+		// V values just return the raw value
+		fallthrough
+	case "W":
+		// W values just return the raw value
+		fallthrough
+	case "P":
+		// P values just return the raw value
+		fallthrough
+	case "G":
+		// G values just return the raw value
+		return dbf.getRawRepresentation(field)
 	default:
 		return nil, newError("dbase-interpreter-valuetobyterepresentation-1", fmt.Errorf("unsupported column data type: %s at column field: %v", field.column.Type(), field.Name()))
 	}
@@ -399,15 +423,15 @@ func (dbf *DBF) getLRepresentation(field *Field) ([]byte, error) {
 }
 
 // Get the raw value as byte representation
-func (dbf *DBF) parseVValue(raw []byte, column *Column) (interface{}, error) {
+func (dbf *DBF) parseRawValue(raw []byte, column *Column) (interface{}, error) {
 	return raw, nil
 }
 
 // Get the raw value as byte representation (only type check for []byte is performed)
-func (dbf *DBF) getVRepresentation(field *Field) ([]byte, error) {
+func (dbf *DBF) getRawRepresentation(field *Field) ([]byte, error) {
 	raw, ok := field.value.([]byte)
 	if !ok {
-		return nil, newError("dbase-interpreter-getvrepresentation-1", fmt.Errorf("invalid data type %T, expected []byte at column field: %v", field.value, field.Name()))
+		return nil, newError("dbase-interpreter-getrawrepresentation-1", fmt.Errorf("invalid data type %T, expected []byte at column field: %v", field.value, field.Name()))
 	}
 	return raw, nil
 }


### PR DESCRIPTION
Added data types:
 - W (Blob)
 - Q (Varbinary)
 - P (Picture)
 - G (General)

> *These types are not interpreted by this package, the raw data is returned. This means the user must interpret the values themselves.*

Closes #14 