### PR TITLE
Implemented better encoding support by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are several similar packages but they are not suited for our use case, thi
 
 | Feature | [go-dbase](https://github.com/Valentin-Kaiser/go-dbase) | [go-dbf](https://github.com/LindsayBradford/go-dbf) | [go-foxpro-dbf](https://github.com/SebastiaanKlippert/go-foxpro-dbf) | 
 | --- | --- | --- | --- |
-| Windows-1250 to UTF8 encoding ¹ | ✅ | ✅ | ✅ |
+| Encoding support ¹ | ✅ | ✅ | ✅ |
 | Read | ✅ | ✅ | ✅ |
 | Write | ✅  | ✅ | ❌ |
 | FPT (memo) file support | ✅ | ❌ | ✅ |
@@ -25,7 +25,7 @@ There are several similar packages but they are not suited for our use case, thi
 | Search by value | ✅ | ❌ | ❌ |
 | Create new tables from scratch | ✅ | ❌ | ❌ |
 
-> ¹ Since these files are almost always used on Windows platforms the default encoding is from Windows-1250 to UTF8 but a universal encoder will be provided for other code pages.
+> ¹ This package currently supports 13 of the 25 possible encodings, but a universal encoder will be provided for other code pages that can be extended at will. A list of supported encodings can be found [here](#supported-encodings).
 
 > ² IO efficiency is achieved by using one file handle for the DBF file and one file handle for the FPT file. This allows for non blocking IO and the ability to read files while other processes are accessing these. In addition, only the required positions in the file are read instead of keeping a copy of the entire file in memory.
 
@@ -65,6 +65,30 @@ The supported column types with their return Go types are:
 > If you need more information about dbase data types take a look here: [Microsoft Visual Studio Foxpro](https://learn.microsoft.com/en-us/previous-versions/visualstudio/foxpro/74zkxe2k(v=vs.80))
 
 > **These types are not interpreted by this package, the raw data is returned. This means the user must interpret the values themselves.*
+
+# Supported encodings
+
+The following encodings are supported by this package:
+
+| Code page | Platform | Code page identifier |
+| --- | --- | --- |
+| 437 | U.S. MS-DOS | x01 |
+| 850 | International MS-DOS | x02 | 
+| 852 | Eastern European MS-DOS	| x64| 
+| 865 | Nordic MS-DOS | x66 | 
+| 866 | Russian MS-DOS | x65 | 
+| 874 | Thai Windows | x7C | 
+| 1250 | Central European Windows | xC8 | 
+| 1251 | Russian Windows | xC9 | 
+| 1252 | Windows ANSI | x03 | 
+| 1253 | Greek Windows	| xCB | 
+| 1254 | Turkish Windows| xCA | 
+| 1255 | Hebrew Windows | x7D | 
+| 1256 | Arabic Windows	| x7E | 
+
+
+
+> All encodings are converted from and to UTF-8.
 
 # Installation
 ``` 

--- a/dbase/encoding.go
+++ b/dbase/encoding.go
@@ -17,15 +17,18 @@ type EncodingConverter interface {
 	CodePageMark() byte
 }
 
-// Win1250Decoder translates a Windows-1250 DBF to UTF8 and back
-type Win1250Converter struct{}
+type DefaultConverter struct {
+	encoding *charmap.Charmap
+}
 
-// Decode decodes a Windows1250 byte slice to a UTF8 byte slice
-func (d *Win1250Converter) Decode(in []byte) ([]byte, error) {
+// Win1250Decoder translates a Windows-1250 DBF to UTF8 and back
+
+// Decode decodes a specified encoding to byte slice to a UTF8 byte slice
+func (c DefaultConverter) Decode(in []byte) ([]byte, error) {
 	if utf8.Valid(in) {
 		return in, nil
 	}
-	r := transform.NewReader(bytes.NewReader(in), charmap.Windows1250.NewDecoder())
+	r := transform.NewReader(bytes.NewReader(in), c.encoding.NewDecoder())
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, newError("dbase-encoding-decode-1", err)
@@ -33,10 +36,10 @@ func (d *Win1250Converter) Decode(in []byte) ([]byte, error) {
 	return data, nil
 }
 
-// Decode decodes a UTF8 byte slice to a Windows1250 byte slice
-func (d *Win1250Converter) Encode(in []byte) ([]byte, error) {
+// Decode decodes a UTF8 byte slice to the specified encoding byte slice
+func (c DefaultConverter) Encode(in []byte) ([]byte, error) {
 	out := make([]byte, len(in))
-	enc := charmap.Windows1250.NewEncoder()
+	enc := c.encoding.NewEncoder()
 	nDst, _, err := enc.Transform(out, in, false)
 	if err != nil {
 		return nil, newError("dbase-encoding-encode-1", err)
@@ -44,7 +47,74 @@ func (d *Win1250Converter) Encode(in []byte) ([]byte, error) {
 	return out[:nDst], nil
 }
 
-// CodePageMark returns the code page mark for the Windows1250 encoding
-func (d *Win1250Converter) CodePageMark() byte {
-	return 0x03
+// CodePageMark returns corresponding code page mark for the encoding
+func (d DefaultConverter) CodePageMark() byte {
+	switch d.encoding {
+	case charmap.CodePage437: // U.S. MS-DOS
+		return 0x01
+	case charmap.CodePage850: // International MS-DOS
+		return 0x02
+	case charmap.CodePage852: // Eastern European MS-DOS
+		return 0x64
+	case charmap.CodePage865: // Nordic MS-DOS
+		return 0x66
+	case charmap.CodePage866: // Russian MS-DOS
+		return 0x65
+	case charmap.Windows874: // Thai Windows
+		return 0x7C
+	case charmap.Windows1250: // Central European Windows
+		return 0xc8
+	case charmap.Windows1251: // Russian Windows
+		return 0xc9
+	case charmap.Windows1252: // Windows ANSI
+		return 0x03
+	case charmap.Windows1253: // Greek Windows
+		return 0xCB
+	case charmap.Windows1254: // Turkish Windows
+		return 0xCA
+	case charmap.Windows1255: // Hebrew Windows
+		return 0x7D
+	case charmap.Windows1256: // Arabic Windows
+		return 0x7E
+	default:
+		return 0x00
+	}
+}
+
+func NewDefaultConverter(encoding *charmap.Charmap) DefaultConverter {
+	return DefaultConverter{encoding: encoding}
+}
+
+// NewDefaultConverterFromCodePage returns a new EncodingConverter from a code page mark
+func NewDefaultConverterFromCodePage(codePageMark byte) DefaultConverter {
+	switch codePageMark {
+	case 0x01: // U.S. MS-DOS
+		return NewDefaultConverter(charmap.CodePage437)
+	case 0x02: // International MS-DOS
+		return NewDefaultConverter(charmap.CodePage850)
+	case 0x64: // Eastern European MS-DOS
+		return NewDefaultConverter(charmap.CodePage852)
+	case 0x66: // Nordic MS-DOS
+		return NewDefaultConverter(charmap.CodePage865)
+	case 0x65: // Russian MS-DOS
+		return NewDefaultConverter(charmap.CodePage866)
+	case 0x7C: // Thai Windows
+		return NewDefaultConverter(charmap.Windows874)
+	case 0xC8: // Central European Windows
+		return NewDefaultConverter(charmap.Windows1250)
+	case 0xC9: // Russian Windows
+		return NewDefaultConverter(charmap.Windows1251)
+	case 0x03: // Windows ANSI
+		return NewDefaultConverter(charmap.Windows1252)
+	case 0xCB: // Greek Windows
+		return NewDefaultConverter(charmap.Windows1253)
+	case 0xCA: // Turkish Windows
+		return NewDefaultConverter(charmap.Windows1254)
+	case 0x7D: // Hebrew Windows
+		return NewDefaultConverter(charmap.Windows1255)
+	case 0x7E: // Arabic Windows
+		return NewDefaultConverter(charmap.Windows1256)
+	default: // Default to Central European Windows
+		return NewDefaultConverter(charmap.Windows1250)
+	}
 }

--- a/dbase/table.go
+++ b/dbase/table.go
@@ -85,6 +85,9 @@ func New(version FileType, config *Config, columns []*Column, memoBlockSize uint
 	if len(columns) == 0 {
 		return nil, errors.New("no columns defined")
 	}
+	if config.Converter == nil {
+		return nil, errors.New("no converter defined")
+	}
 	dbf := &DBF{
 		config: config,
 		header: &Header{

--- a/examples/create/create.go
+++ b/examples/create/create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Valentin-Kaiser/go-dbase/dbase"
+	"golang.org/x/text/encoding/charmap"
 )
 
 func main() {
@@ -37,7 +38,7 @@ func main() {
 		dbase.FoxProVar,
 		&dbase.Config{
 			Filename:   "test.dbf",
-			Converter:  new(dbase.Win1250Converter),
+			Converter:  dbase.NewDefaultConverter(charmap.Windows1250),
 			TrimSpaces: true,
 		},
 		[]*dbase.Column{

--- a/examples/read/read.go
+++ b/examples/read/read.go
@@ -26,7 +26,6 @@ func main() {
 	// Open the example database file.
 	dbf, err := dbase.Open(&dbase.Config{
 		Filename:   "../test_data/TEST.DBF",
-		Converter:  new(dbase.Win1250Converter),
 		TrimSpaces: true,
 	})
 	if err != nil {

--- a/examples/search/search.go
+++ b/examples/search/search.go
@@ -9,8 +9,7 @@ import (
 func main() {
 	// Open the example database file.
 	dbf, err := dbase.Open(&dbase.Config{
-		Filename:  "../test_data/TEST.DBF",
-		Converter: new(dbase.Win1250Converter),
+		Filename: "../test_data/TEST.DBF",
 	})
 	if err != nil {
 		panic(err)

--- a/examples/write/write.go
+++ b/examples/write/write.go
@@ -26,7 +26,6 @@ func main() {
 	// Open the example database file.
 	dbf, err := dbase.Open(&dbase.Config{
 		Filename:   "../test_data/TEST.DBF",
-		Converter:  new(dbase.Win1250Converter),
 		TrimSpaces: true,
 		WriteLock:  true,
 	})


### PR DESCRIPTION
The EncodingConverter can interpret the used code page and now supports these encodings by default: 

-  U.S. MS-DOS x01
-  International MS-DOS x02
-  Eastern European MS-DOS x64
-  Nordic MS-DOS x66
-  Russian MS-DOS x65
-  Thai Windows x7C
-  Eastern European Windows xC8
-  Russian Windows xC9
-  Windows ANSI x03
-  Greek Windows xCB
-  Turkish Windows xCA
-  Hebrew Windows x7D
-  Arabic Windows x7E


Issue #32 