### PR TITLE
fix: check string size after converting to the target encoding

### DIFF
--- a/dbase/interpreter.go
+++ b/dbase/interpreter.go
@@ -195,13 +195,13 @@ func (file *File) getCharacterRepresentation(field *Field, skipSpacing bool) ([]
 	if !ok {
 		return nil, NewErrorf("invalid data type %T, expected string on column field: %v", field.value, field.Name())
 	}
-	if len(c) > MaxCharacterLength {
-		return nil, NewErrorf("invalid length %v bytes > %v bytes at column field: %v", len(c), MaxCharacterLength, field.Name())
-	}
 	raw := make([]byte, field.column.Length)
 	bin, err := fromUtf8String([]byte(c), file.config.Converter)
 	if err != nil {
 		return nil, NewErrorf("parsing from utf8 string at column field: %v failed", field.Name()).Details(err)
+	}
+	if len(bin) > MaxCharacterLength {
+		return nil, NewErrorf("invalid length %v bytes > %v bytes at column field: %v", len(bin), MaxCharacterLength, field.Name())
 	}
 	if skipSpacing {
 		return bin, nil


### PR DESCRIPTION
Since byte size of the character varies between utf8 and other encodings it makes sense to validate string length after converting to the target encoding not before.
E.g. a cyrillic string in utf-8 is going to take 2 times more bytes than the same string in windows-1251