### PR TITLE
fix: don't override header for existing tables

### DIFF
--- a/dbase/file.go
+++ b/dbase/file.go
@@ -20,6 +20,7 @@ type File struct {
 	memoMutex      *sync.Mutex // Mutex locks for concurrent writing access to the FPT file.
 	table          *Table      // Containing the columns and internal row pointer.
 	nullFlagColumn *Column     // The column containing the null flag column (if varchar or varbinary field exists).
+	isNew          bool
 }
 
 func (file *File) TableName() string {

--- a/dbase/io.go
+++ b/dbase/io.go
@@ -43,6 +43,7 @@ func (file *File) Close() error {
 
 // Creates a new dBase database file (and the memo file if needed).
 func (file *File) Create() error {
+	file.isNew = true
 	return file.defaults().io.Create(file)
 }
 

--- a/dbase/io_generic.go
+++ b/dbase/io_generic.go
@@ -260,14 +260,16 @@ func (g GenericIO) WriteColumns(file *File) error {
 	if err != nil {
 		return NewErrorf("failed to write column terminator").Details(err)
 	}
-	// Write null till the end of the header
-	pos := file.header.FirstRow - uint16(len(file.table.columns)*32) - 33
-	if file.nullFlagColumn != nil {
-		pos -= 32
-	}
-	_, err = handle.Write(make([]byte, pos))
-	if err != nil {
-		return NewErrorf("failed to write null till end of header").Details(err)
+	if file.isNew {
+		// Write null till the end of the header
+		pos := file.header.FirstRow - uint16(len(file.table.columns)*32) - 33
+		if file.nullFlagColumn != nil {
+			pos -= 32
+		}
+		_, err = handle.Write(make([]byte, pos))
+		if err != nil {
+			return NewErrorf("failed to write null till end of header").Details(err)
+		}
 	}
 	return nil
 }

--- a/dbase/io_windows.go
+++ b/dbase/io_windows.go
@@ -369,14 +369,17 @@ func (w WindowsIO) WriteColumns(file *File) (err error) {
 	if err != nil {
 		return NewErrorf("writing column terminator failed").Details(err)
 	}
-	// Write null till the end of the header
-	pos := file.header.FirstRow - uint16(len(file.table.columns)*32) - 33
-	if file.nullFlagColumn != nil {
-		pos -= 32
-	}
-	_, err = windows.Write(*handle, make([]byte, pos))
-	if err != nil {
-		return NewErrorf("writing null till the end of the header failed").Details(err)
+
+	if file.isNew {
+		// Write null till the end of the header
+		pos := file.header.FirstRow - uint16(len(file.table.columns)*32) - 33
+		if file.nullFlagColumn != nil {
+			pos -= 32
+		}
+		_, err = windows.Write(*handle, make([]byte, pos))
+		if err != nil {
+			return NewErrorf("writing null till the end of the header failed").Details(err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This commit introduces `isNew` flag for a file to be able to differntiate between existing tables and newly created ones. Before this fix writing to an existing table broke backlinks