### PR TITLE
perf(dbase): replace per-call dispatch maps with switches in Interpret/Represent

### DIFF
--- a/dbase/interpreter.go
+++ b/dbase/interpreter.go
@@ -35,95 +35,112 @@ import (
 //
 // Not all available column types have been implemented because we don't use them in our DBFs
 func (file *File) Interpret(raw []byte, column *Column) (interface{}, error) {
-	var funcs = map[DataType]func([]byte, *Column) (interface{}, error){
-		// M values contain the address in the FPT file from where to read data
-		Memo: file.parseMemo,
-		// C values are stored as strings, the returned string is not trimmed
-		Character: file.parseCharacter,
-		// I values are stored as numeric values
-		Integer: file.parseInteger,
-		// Y values are currency values stored as ints with 4 decimal places
-		Currency: file.parseCurrency,
-		// F values are stored as string values
-		Float: file.parseFloat,
-		// B (double) values are stored as numeric values
-		Double: file.parseDouble,
-		// D values are stored as string in format YYYYMMDD, convert to time.Time
-		Date: file.parseDate,
-		// T values are stores as two 4 byte integers
-		//  integer one is the date in julian format
-		//  integer two is the number of milliseconds since midnight
-		DateTime: file.parseDateTime,
-		// L values are stored as strings T or F, we only check for T, the rest is false...
-		Logical: file.parseLogical,
-		// N values are stored as string values, if no decimals return as int64, if decimals treat as float64
-		Numeric: file.parseNumeric,
-		// V and Q values just return the raw value
-		Varchar:   file.parseVarchar,
-		Varbinary: file.parseVarbinary,
-		// W, P and G values just return the raw value
-		Blob:    file.parseRaw,
-		Picture: file.parseRaw,
-		General: file.parseRaw,
-	}
-
 	if len(raw) != int(column.Length) {
 		return nil, NewErrorf("invalid length %v Bytes != %v Bytes at column field: %v", len(raw), column.Length, column.Name())
 	}
 
-	f, ok := funcs[DataType(column.DataType)]
-	if !ok {
+	// A switch is used instead of a lookup table because Interpret runs once per
+	// column of every row. Building a map of bound method values here would
+	// allocate the map and all its closures on every single call.
+	switch DataType(column.DataType) {
+	// M values contain the address in the FPT file from where to read data
+	case Memo:
+		return file.parseMemo(raw, column)
+	// C values are stored as strings, the returned string is not trimmed
+	case Character:
+		return file.parseCharacter(raw, column)
+	// I values are stored as numeric values
+	case Integer:
+		return file.parseInteger(raw, column)
+	// Y values are currency values stored as ints with 4 decimal places
+	case Currency:
+		return file.parseCurrency(raw, column)
+	// F values are stored as string values
+	case Float:
+		return file.parseFloat(raw, column)
+	// B (double) values are stored as numeric values
+	case Double:
+		return file.parseDouble(raw, column)
+	// D values are stored as string in format YYYYMMDD, convert to time.Time
+	case Date:
+		return file.parseDate(raw, column)
+	// T values are stores as two 4 byte integers
+	//  integer one is the date in julian format
+	//  integer two is the number of milliseconds since midnight
+	case DateTime:
+		return file.parseDateTime(raw, column)
+	// L values are stored as strings T or F, we only check for T, the rest is false...
+	case Logical:
+		return file.parseLogical(raw, column)
+	// N values are stored as string values, if no decimals return as int64, if decimals treat as float64
+	case Numeric:
+		return file.parseNumeric(raw, column)
+	// V and Q values just return the raw value
+	case Varchar:
+		return file.parseVarchar(raw, column)
+	case Varbinary:
+		return file.parseVarbinary(raw, column)
+	// W, P and G values just return the raw value
+	case Blob, Picture, General:
+		return file.parseRaw(raw, column)
+	default:
 		return nil, NewErrorf("unsupported column data type: %s at column field: %v", DataType(column.DataType), column.Name())
 	}
-
-	return f(raw, column)
 }
 
 // Represent converts column data to the byte representation of the columns data type
 // For M values the data is written to the memo file and the address is returned
 func (file *File) Represent(field *Field, padding bool) ([]byte, error) {
-	var funcs = map[DataType]func(*Field, bool) ([]byte, error){
-		// M values contain the address in the FPT file from where to read data
-		Memo: file.getMemoRepresentation,
-		// C values are stored as strings, the returned string is not trimmed
-		Character: file.getCharacterRepresentation,
-		// I values (int32)
-		Integer: file.getIntegerRepresentation,
-		// Y (currency)
-		Currency: file.getCurrencyRepresentation,
-		// F (Float)
-		Float: file.getFloatRepresentation,
-		// B (double)
-		Double: file.getDoubleRepresentation,
-		// D values are stored as string in format YYYYMMDD, convert to time.Time
-		Date: file.getDateRepresentation,
-		// T values are stores as two 4 byte integers
-		//  integer one is the date in julian format
-		//  integer two is the number of milliseconds since midnight
-		DateTime: file.getDateTimeRepresentation,
-		// L (bool) values are stored as strings T or F, we only check for T, the rest is false...
-		Logical: file.getLogicalRepresentation,
-		// N values are stored as string values, if no decimals return as int64, if decimals treat as float64
-		Numeric: file.getNumericRepresentation,
-		// V and Q values just return the raw value
-		Varchar:   file.getVarcharRepresentation,
-		Varbinary: file.getVarbinaryRepresentation,
-		// W, P and G values just return the raw value
-		Blob:    file.getRawRepresentation,
-		Picture: file.getRawRepresentation,
-		General: file.getRawRepresentation,
-	}
-
 	if field.GetValue() == nil {
 		return make([]byte, field.column.Length), nil
 	}
 
-	f, ok := funcs[DataType(field.column.DataType)]
-	if !ok {
+	// See Interpret: a switch avoids allocating a map of bound method values on
+	// every call.
+	switch DataType(field.column.DataType) {
+	// M values contain the address in the FPT file from where to read data
+	case Memo:
+		return file.getMemoRepresentation(field, padding)
+	// C values are stored as strings, the returned string is not trimmed
+	case Character:
+		return file.getCharacterRepresentation(field, padding)
+	// I values (int32)
+	case Integer:
+		return file.getIntegerRepresentation(field, padding)
+	// Y (currency)
+	case Currency:
+		return file.getCurrencyRepresentation(field, padding)
+	// F (Float)
+	case Float:
+		return file.getFloatRepresentation(field, padding)
+	// B (double)
+	case Double:
+		return file.getDoubleRepresentation(field, padding)
+	// D values are stored as string in format YYYYMMDD, convert to time.Time
+	case Date:
+		return file.getDateRepresentation(field, padding)
+	// T values are stores as two 4 byte integers
+	//  integer one is the date in julian format
+	//  integer two is the number of milliseconds since midnight
+	case DateTime:
+		return file.getDateTimeRepresentation(field, padding)
+	// L (bool) values are stored as strings T or F, we only check for T, the rest is false...
+	case Logical:
+		return file.getLogicalRepresentation(field, padding)
+	// N values are stored as string values, if no decimals return as int64, if decimals treat as float64
+	case Numeric:
+		return file.getNumericRepresentation(field, padding)
+	// V and Q values just return the raw value
+	case Varchar:
+		return file.getVarcharRepresentation(field, padding)
+	case Varbinary:
+		return file.getVarbinaryRepresentation(field, padding)
+	// W, P and G values just return the raw value
+	case Blob, Picture, General:
+		return file.getRawRepresentation(field, padding)
+	default:
 		return nil, NewErrorf("unsupported column data type: %s at column field: %v", DataType(field.column.DataType), field.Name())
 	}
-
-	return f(field, padding)
 }
 
 // Returns the value from the memo file as string or []byte

--- a/dbase/interpreter_bench_test.go
+++ b/dbase/interpreter_bench_test.go
@@ -1,0 +1,235 @@
+package dbase
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/text/encoding/charmap"
+)
+
+// benchRows is the number of rows written into the synthetic table used by the
+// read benchmarks. It is large enough for the per-row cost to dominate the
+// fixed cost of opening the file, while keeping the setup phase fast.
+const benchRows = 10000
+
+// benchColumns builds a 15 column layout that covers every data type reachable
+// through Interpret without requiring a memo (FPT) file, so the benchmarks
+// measure conversion instead of memo I/O.
+func benchColumns(tb testing.TB) []*Column {
+	tb.Helper()
+
+	specs := []struct {
+		name     string
+		dataType DataType
+		length   uint8
+		decimals uint8
+	}{
+		{"CODE", Character, 20, 0},
+		{"NAME", Character, 50, 0},
+		{"DESCR", Character, 100, 0},
+		{"UNIT", Character, 10, 0},
+		{"TAG", Character, 15, 0},
+		{"QTY", Numeric, 12, 0},
+		{"PRICE", Numeric, 14, 4},
+		{"TOTAL", Numeric, 14, 2},
+		{"RATE", Float, 12, 4},
+		{"WEIGHT", Double, 0, 0},
+		{"AMOUNT", Currency, 0, 0},
+		{"ID", Integer, 0, 0},
+		{"ACTIVE", Logical, 0, 0},
+		{"CREATED", Date, 0, 0},
+		{"UPDATED", DateTime, 0, 0},
+	}
+
+	columns := make([]*Column, 0, len(specs))
+	for _, spec := range specs {
+		column, err := NewColumn(spec.name, spec.dataType, spec.length, spec.decimals, false)
+		if err != nil {
+			tb.Fatalf("creating column %s failed: %v", spec.name, err)
+		}
+		columns = append(columns, column)
+	}
+	return columns
+}
+
+// benchValues returns a plausible value for every column of the layout above.
+func benchValues(i int) map[string]interface{} {
+	return map[string]interface{}{
+		"CODE":    fmt.Sprintf("ART-%08d", i),
+		"NAME":    fmt.Sprintf("Product number %d", i),
+		"DESCR":   "A reasonably long description of the product to fill the column",
+		"UNIT":    "pcs",
+		"TAG":     "tag",
+		"QTY":     int64(i % 1000),
+		"PRICE":   float64(i%10000) + 0.5,
+		"TOTAL":   float64(i%10000) * 1.25,
+		"RATE":    float64(i%100) / 3.0,
+		"WEIGHT":  float64(i) * 0.125,
+		"AMOUNT":  float64(i%10000) + 0.25,
+		"ID":      int32(i),
+		"ACTIVE":  i%2 == 0,
+		"CREATED": time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, i%365),
+		"UPDATED": time.Date(2024, time.January, 1, 12, 30, 15, 0, time.UTC).Add(time.Duration(i) * time.Minute),
+	}
+}
+
+// benchTable writes a synthetic table with benchRows rows into a temporary
+// directory and returns its path. The repository ships no fixture large enough
+// to make per-row costs visible, so the table is generated on the fly using the
+// package's own writing support.
+//
+// The directory is created relative to the working directory and with an
+// upper case name on purpose: the Create implementations upper case the whole
+// path, so a table cannot be created below a lower case directory such as the
+// one returned by testing.TB.TempDir.
+func benchTable(tb testing.TB) string {
+	tb.Helper()
+
+	dir, err := os.MkdirTemp(".", "BENCHDATA")
+	if err != nil {
+		tb.Fatalf("creating bench directory failed: %v", err)
+	}
+	tb.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+
+	path := filepath.Join(dir, "BENCH.DBF")
+	file, err := NewTable(
+		FoxPro,
+		&Config{
+			Filename:   path,
+			Converter:  NewDefaultConverter(charmap.Windows1250),
+			TrimSpaces: true,
+		},
+		benchColumns(tb),
+		0,
+		nil,
+	)
+	if err != nil {
+		tb.Fatalf("creating bench table failed: %v", err)
+	}
+
+	for i := 0; i < benchRows; i++ {
+		row, err := file.RowFromMap(benchValues(i))
+		if err != nil {
+			tb.Fatalf("building row %d failed: %v", i, err)
+		}
+		if err := row.Add(); err != nil {
+			tb.Fatalf("writing row %d failed: %v", i, err)
+		}
+	}
+
+	if err := file.Close(); err != nil {
+		tb.Fatalf("closing bench table failed: %v", err)
+	}
+	return path
+}
+
+// benchOpen opens the synthetic table for reading.
+func benchOpen(tb testing.TB, path string) *File {
+	tb.Helper()
+
+	file, err := OpenTable(&Config{Filename: path, TrimSpaces: true})
+	if err != nil {
+		tb.Fatalf("opening bench table failed: %v", err)
+	}
+	tb.Cleanup(func() {
+		_ = file.Close()
+	})
+	return file
+}
+
+// BenchmarkTableReadAll walks the whole table with Next and Values, which is
+// the hot path of the library: Next -> Row -> BytesToRow -> Interpret, once per
+// column of every row.
+func BenchmarkTableReadAll(b *testing.B) {
+	file := benchOpen(b, benchTable(b))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if err := file.GoTo(0); err != nil {
+			b.Fatalf("seeking to first row failed: %v", err)
+		}
+		for !file.EOF() {
+			row, err := file.Next()
+			if err != nil {
+				b.Fatalf("reading row failed: %v", err)
+			}
+			_ = row.Values()
+		}
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*benchRows), "ns/row")
+}
+
+// BenchmarkBytesToRow isolates the row decoding step from the file I/O by
+// converting one pre-read row buffer over and over.
+func BenchmarkBytesToRow(b *testing.B) {
+	file := benchOpen(b, benchTable(b))
+
+	data, err := file.ReadRow(0)
+	if err != nil {
+		b.Fatalf("reading row failed: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if _, err := file.BytesToRow(data); err != nil {
+			b.Fatalf("converting row failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkInterpret measures Interpret alone, once per column of a single row.
+func BenchmarkInterpret(b *testing.B) {
+	file := benchOpen(b, benchTable(b))
+
+	data, err := file.ReadRow(0)
+	if err != nil {
+		b.Fatalf("reading row failed: %v", err)
+	}
+
+	columns := file.Columns()
+	raws := make([][]byte, len(columns))
+	offset := uint16(1)
+	for i, column := range columns {
+		raws[i] = data[offset : offset+uint16(column.Length)]
+		offset += uint16(column.Length)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for i, column := range columns {
+			if _, err := file.Interpret(raws[i], column); err != nil {
+				b.Fatalf("interpreting column %s failed: %v", column.Name(), err)
+			}
+		}
+	}
+}
+
+// BenchmarkRepresent measures Represent alone, once per column of a single row.
+func BenchmarkRepresent(b *testing.B) {
+	file := benchOpen(b, benchTable(b))
+
+	row, err := file.Row()
+	if err != nil {
+		b.Fatalf("reading row failed: %v", err)
+	}
+	fields := row.Fields()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, field := range fields {
+			if _, err := file.Represent(field, true); err != nil {
+				b.Fatalf("representing column %s failed: %v", field.Name(), err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`File.Interpret` builds a 15 entry dispatch map on **every call**:

```go
func (file *File) Interpret(raw []byte, column *Column) (interface{}, error) {
	var funcs = map[DataType]func([]byte, *Column) (interface{}, error){
		Memo:      file.parseMemo,
		Character: file.parseCharacter,
		...
	}
```

The map values are method values bound to `file`, so the composite literal depends on the receiver and the compiler cannot hoist it out of the function. Every call therefore allocates the map plus fifteen closures, uses exactly one of them, and throws all of it away.

`Interpret` is on the hottest path in the library: `File.Next()` -> `File.Row()` -> `File.BytesToRow()` calls it **once per column of every row**. On a table with 15 columns that is 16 wasted allocations per column, 240 per row.

`File.Represent` in the same file has the identical pattern on the write path.

## Fix

Replace both maps with a plain `switch` on the data type. The dispatch stays exactly the same, the allocations go away. The explanatory comments that sat next to each map entry were moved onto the corresponding `switch` cases so nothing is lost.

## Measured improvement

Benchmarks added in `dbase/interpreter_bench_test.go`. The repository ships no fixture large enough for per-row costs to be visible, so the benchmark generates a synthetic 10 000 row / 15 column table using the package's own writing support (Character, Numeric, Float, Double, Currency, Integer, Logical, Date, DateTime), then walks it with `Next()` and `Values()` — the same shape as a real read loop.

`go test -run XXX -bench . -count=10`, compared with `benchstat` (Go 1.26, linux/amd64, AMD Ryzen 9 5900X):

```
                │    old.txt    │               new.txt               │
                │    sec/op     │   sec/op     vs base                │
TableReadAll-24    158.52m ± 3%   39.34m ± 1%  -75.18% (p=0.000 n=10)
BytesToRow-24      13.370µ ± 2%   1.809µ ± 1%  -86.47% (p=0.000 n=10)
Interpret-24      12469.0n ± 1%   954.3n ± 1%  -92.35% (p=0.000 n=10)
Represent-24       12.911µ ± 2%   1.345µ ± 2%  -89.58% (p=0.000 n=10)
geomean             135.9µ        17.38µ       -87.21%

                │   old.txt    │               new.txt               │
                │   sec/row    │   sec/row    vs base                │
TableReadAll-24   15.852µ ± 3%   3.934µ ± 2%  -75.19% (p=0.000 n=10)

                │    old.txt    │               new.txt                │
                │     B/op      │     B/op      vs base                │
TableReadAll-24   145.84Mi ± 0%   23.39Mi ± 0%  -83.96% (p=0.000 n=10)
BytesToRow-24     14.109Ki ± 0%   1.570Ki ± 0%  -88.87% (p=0.000 n=10)
Interpret-24       13328.0 ± 0%     488.0 ± 0%  -96.34% (p=0.000 n=10)
Represent-24      13.766Ki ± 0%   1.227Ki ± 0%  -91.09% (p=0.000 n=10)
geomean            139.4Ki        12.18Ki       -91.26%

                │   old.txt    │               new.txt               │
                │  allocs/op   │  allocs/op   vs base                │
TableReadAll-24   3346.6k ± 0%   646.6k ± 0%  -80.68% (p=0.000 n=10)
BytesToRow-24      321.00 ± 0%    51.00 ± 0%  -84.11% (p=0.000 n=10)
Interpret-24       294.00 ± 0%    24.00 ± 0%  -91.84% (p=0.000 n=10)
Represent-24       317.00 ± 0%    47.00 ± 0%  -85.17% (p=0.000 n=10)
geomean            3.163k         439.2       -86.12%
```

A full table scan gets **4.0x faster** (15.9 µs/row -> 3.9 µs/row) and allocates 84 % less memory, from this change alone.

This matches what I originally hit in production: a real Visual FoxPro table with 122 278 rows and 15 columns took **3.29 s** to read with `Next()`/`Values()` before and **0.78 s** after (a bare sequential read of the same file for reference: 0.12 s) — a 4.2x speedup.

## Behaviour is unchanged

* Both error cases and their exact messages are preserved: the length mismatch in `Interpret` and the "unsupported column data type" default in both functions.
* The order of the guard clauses is preserved. `Interpret` still checks the raw length before dispatching, `Represent` still returns the zero-filled buffer for a `nil` value first. Building the map had no side effects and could not fail, so evaluating the guard before the dispatch is equivalent.
* Every parse/represent helper is still called with the same arguments (`raw, column` / `field, padding`).
* As an extra check I dumped, for every row of every `.dbf` fixture in `examples/test_data`, the Go type, the `%#v` rendering of every interpreted value and the `Represent` output of every field, on both the old and the new code. The two dumps are byte identical.

## Verification

* `gofmt -l dbase/interpreter.go dbase/interpreter_bench_test.go` — clean
* `go vet ./...` — clean
* `go build ./...` — ok
* `go test ./...` and `go test -race ./...` — 126 tests pass, `TestOpenDatabaseFromBytes` fails. That failure is **pre-existing on a clean checkout of `main`** (`bytes_test.go:284: Failed to open database from bytes: no related handle defined`) and is unrelated to this change; the pass/fail set is identical before and after.
* `golangci-lint run ./...` reports 23 issues on `main`, none of them in the files touched here, and this change adds none.
